### PR TITLE
add support for typscript ext so imports don't have to use .ts(x)

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -147,6 +147,16 @@ const base = {
   }
 };
 
+// typescript mods
+// -----------------------------------------------------------------------------
+base.resolve.extensions = [
+  // webpack defaults
+  // see: https://webpack.js.org/configuration/resolve/#resolve-extensions
+  '.wasm', '.mjs', '.js', '.json',
+  // typescript extensions
+  '.ts', '.tsx'
+];
+
 // development config
 // -----------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes #2.

I learned about modifying webpack's `resolve.extensions` from the README for [ts-loader](https://github.com/TypeStrong/ts-loader).

`ts-loader` seems like it could bring a lot to the table, but integration should probably be implemented by someone more familiar with typescript workflows in the context of webpack/babel.

Even with the current setup, via the development pipeline we get source maps for the typescript files (which support breakpoints in the original sources) so it's a pretty good setup already, using just `@babel/preset-typescript`.