### PR TITLE
Fix blockchain config accounts parameter

### DIFF
--- a/config/blockchain.js
+++ b/config/blockchain.js
@@ -27,11 +27,11 @@ module.exports = {
     targetGasLimit: 8000000, // Target gas limit sets the artificial target gas floor for the blocks to mine
     simulatorMnemonic: "example exile argue silk regular smile grass bomb merge arm assist farm", // Mnemonic  used by the simulator to generate a wallet
     simulatorBlocktime: 0, // Specify blockTime in seconds for automatic mining. Default is 0 and no auto-mining.
-    account: {
+    accounts: [{
       // numAccounts: 3, // When specified, creates accounts for use in the dapp. This option only works in the development environment, and can be used as a quick start option that bypasses the need for MetaMask in development. These accounts are unlocked and funded with the below settings.
       // password: "config/development/password", // Password for the created accounts (as specified in the `numAccounts` setting)
       // balance: "5 ether" // Balance to be given to the created accounts (as specified in the `numAccounts` setting)
-    }
+    }]
   },
 
   // merges with the settings in default
@@ -46,10 +46,10 @@ module.exports = {
     nodiscover: true,
     maxpeers: 0,
     proxy: true,
-    account: {
+    accounts: [{
       // "address": "", // When specified, uses that address instead of the default one for the network
       password: "config/privatenet/password" // Password to unlock the account
-    },
+    }],
     targetGasLimit: 8000000,
     simulatorMnemonic: "example exile argue silk regular smile grass bomb merge arm assist farm",
     simulatorBlocktime: 0
@@ -60,9 +60,9 @@ module.exports = {
   testnet: {
     networkType: "testnet",
     syncMode: "light",
-    account: {
+    accounts: [{
       password: "config/testnet/password"
-    }
+    }]
   },
 
   // merges with the settings in default
@@ -72,9 +72,9 @@ module.exports = {
     syncMode: "light",
     rpcCorsDomain: "http://localhost:8000",
     wsOrigins: "http://localhost:8000",
-    account: {
+    accounts: [{
       password: "config/livenet/password"
-    }
+    }]
   },
 
   // you can name an environment with specific settings and then specify with


### PR DESCRIPTION
Looks like in embark v4 the account parameter was changed for accounts and is an array instead of an object, this fix the error throw when you want to use this template with embark v4.